### PR TITLE
Reduce Stale Bot Thresholds

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
         stale-issue-message: There has been no activity on this issue in four weeks. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback.
         close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback.
         days-before-issue-stale: 28
-        days-before-issue-close: 7 
+        days-before-issue-close: 7
         exempt-issue-labels: discussions-to,long-term
         stale-issue-label: stale
         # PR config

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,17 +20,17 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         ascending: true # Since we have so many issues, the stale bot finds it hard to keep track. This makes sure that at least the oldest are removed.
         # Issue config
-        stale-issue-message: There has been no activity on this issue in three months. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback.
+        stale-issue-message: There has been no activity on this issue in four weeks. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback.
         close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback.
-        days-before-issue-stale: 90
-        days-before-issue-close: 7
+        days-before-issue-stale: 28
+        days-before-issue-close: 7 
         exempt-issue-labels: discussions-to,long-term
         stale-issue-label: stale
         # PR config
-        stale-pr-message: There has been no activity on this pull request in two months. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback or request a review in a comment.
+        stale-pr-message: There has been no activity on this pull request in a week. It will be closed in two weeks if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback or request a review in a comment.
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
-        days-before-pr-stale: 60
-        days-before-pr-close: 7
+        days-before-pr-stale: 7
+        days-before-pr-close: 14
         exempt-pr-labels: long-term
         only-pr-labels: newEIPFile,updateEIP,statusChange
-        stale-pr-label: stale
+        stale-pr-label: "waiting: response from author"


### PR DESCRIPTION
## Abstract

The stale bot thresholds are too high. This PR reduces them.

## Motivation

Reduces EIP Editor work.

## Specification

1. The stale issue threshold was reduced from 3 months to four weeks
2. The stale PR threshold was reduced from two months to one week
3. The close PR threshold was *increased* from one week to two weeks
4. The stale PR label was changed to a more descriptive one

## Rationale

1. Encourages people to discuss relevant issues, and reduces the time it takes for irrelevant issues to disappear. Issues may be re-opened at any time if they become relevant again.
2. Encourages authors to update their EIP with editor-provided feedback or remind editors to review. PRs may be re-opened at any time if the author re-gains interest.
3. Since item 2 reduced the threshold so much, the PR close threshold was increased to give authors enough time to ensure that their PRs will not be mistakenly closed.
4. If the editors are actually the ones that need to review, the author will quickly make that clear, which will remove the stale tag.